### PR TITLE
Significant rework of offset calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,15 @@ ln -s ~/qidi_auto_z_offset/auto_z_offset.py ~/klipper/klippy/extras/auto_z_offse
 
 ### Command Reference
 **AUTO_Z_PROBE**: Probe Z-height at current XY position using the bed sensors
+
 **AUTO_Z_HOME_Z**: Home Z using the bed sensors as an endstop
+
 **AUTO_Z_MEASURE_OFFSET** Z-Offset measured by the inductive probe after AUTO_Z_HOME_Z
+
 **AUTO_Z_CALIBRATE**: Set the Z-Offset by averaging multiple runs of AUTO_Z_MEASURE_OFFSET
+
 **AUTO_Z_LOAD_OFFSET**: Set the Z-Offset by averaging multiple runs of AUTO_Z_MEASURE_OFFSET
+
 **AUTO_Z_SAVE_GCODE_OFFSET**: Save the current gcode offset for z as the new calibrated_z_offset
 
 ### Config Reference

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ ln -s ~/qidi_auto_z_offset/auto_z_offset.py ~/klipper/klippy/extras/auto_z_offse
 [auto_z_offset]
 pin:
 #   Pin connected to the Auto Z Offset output pin. This parameter is required.
+z_offset: 0.0
+#   Unused in actual code, but required because this is technically probe.
 #probe_accel:
 #   If set, limits the acceleration of the probing moves (in mm/sec^2).
 #   A sudden large acceleration at the beginning of the probing move may

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ ln -s ~/qidi_auto_z_offset/auto_z_offset.py ~/klipper/klippy/extras/auto_z_offse
 **AUTO_Z_HOME_Z**: Home Z using the bed sensors as an endstop
 **AUTO_Z_MEASURE_OFFSET** Z-Offset measured by the inductive probe after AUTO_Z_HOME_Z
 **AUTO_Z_CALIBRATE**: Set the Z-Offset by averaging multiple runs of AUTO_Z_MEASURE_OFFSET
+**AUTO_Z_LOAD_OFFSET**: Set the Z-Offset by averaging multiple runs of AUTO_Z_MEASURE_OFFSET
+**AUTO_Z_SAVE_GCODE_OFFSET**: Save the current gcode offset for z as the new calibrated_z_offset
 
 ### Config Reference
 ```

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ This is a plugin for Klipper that makes use of the QIDI Q1 Pro's bed sensors to 
 
 ### Install
 ```
-ln -s <path to>/auto_z_offset.py <path to>/klipper/klippy/extras/auto_z_offset.py
+cd ~
+git clone https://github.com/frap129/qidi_auto_z_offset
+ln -s ~/qidi_auto_z_offset/auto_z_offset.py ~/klipper/klippy/extras/auto_z_offset.py
 ```
 
 ### Command Reference
-**AUTO_Z_CALIBRATE**: `AUTO_Z_CALIBRATE` "probes" the bed to measure z-offset
+**AUTO_Z_PROBE**: `AUTO_Z_PROBE` works like the normal PROBE command, using the bed sensors instead.
+**AUTO_Z_OFFSET**: `AUTO_Z_OFFSET` uses the probe and the bed sensor to approximate the Z offset as `auto_z_probe_result + probe_result + z_offset` where `z_offset` is the fixed value set in the auto_z_offset config.
 
 ### Config Reference
 ```
@@ -21,12 +24,12 @@ pin:
 #   cause spurious probe triggering, especially if the hotend is heavy.
 #   To prevent that, it may be necessary to reduce the acceleration of
 #   the probing moves via this parameter.
-#x_offset:
-#y_offset:
-#   Should be left unset (or set to 0).
 z_offset:
 #   Offset to adjust the final z-offset value by after probing . Note that this
 #   is not the same as a traditional probe's z_offset.
+prepare_gcode:
+#   gcode script to run before probing with AUTO_Z. This is required, and an
+#   example script is provided below.
 #speed:
 #samples:
 #sample_retract_dist:
@@ -38,3 +41,44 @@ z_offset:
 #deactivate_on_each_sample:
 #   See the "probe" section for more information on the parameters above.
 ```
+
+### Example Configuration from OpenQ1
+This example config also includes the control pin for the bed sensors and the config for the inductive probe. Use them as shown for the best compatiblity.
+```
+[output_pin bed_sensor]
+pin: !U_1:PA14
+value:0
+
+[probe]
+pin:!gpio21
+x_offset: 17.6
+y_offset: 4.4
+z_offset: 0.0
+speed:10
+samples: 3
+samples_result: average
+sample_retract_dist: 3.0
+samples_tolerance: 0.05
+samples_tolerance_retries: 5
+
+[auto_z_offset]
+pin: U_1:PC1
+z_offset: 0.0
+speed: 10
+probe_accel: 50
+samples: 3
+samples_result: average
+samples_tolerance: 0.05
+samples_tolerance_retries: 5
+prepare_gcode:
+    SET_PIN PIN=bed_sensor VALUE=0
+    G91
+    {% set i = 4 %}
+    {% for iteration in range(i|int) %}
+        G1 Z1 F900
+        G1 Z-1 F900
+    {% endfor %}
+    G90
+    SET_PIN PIN=bed_sensor VALUE=1
+```
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This is a plugin for Klipper that makes use of the QIDI Q1 Pro's bed sensors to automatically set the toolheads Z-Offset.
 
+⚠️ **NOTE** ⚠️
+This should not be used at the begining of a print! If the bed sensors fail to trigger, or trigger to late, you can end up
+grinding the nozzle into the bed when you got to start a print. Instead, you should run `AUTO_Z_CALIBRATE_OFFSET` prior to
+your first print, move Z to 0, and verify that you can slide a piece of paper under the nozzle.
+
 ### Install
 ```
 cd ~
@@ -10,24 +15,28 @@ ln -s ~/qidi_auto_z_offset/auto_z_offset.py ~/klipper/klippy/extras/auto_z_offse
 ```
 
 ### Command Reference
-**AUTO_Z_PROBE**: `AUTO_Z_PROBE` works like the normal PROBE command, using the bed sensors instead.
-**AUTO_Z_CALIBRATE**: `AUTO_Z_CALIBRATE` uses the bed sensor as a Z endstop, then probes with the inductive probe. Averages the values reported by each to find the approximate offset.
+**AUTO_Z_PROBE**: Probe Z-height at current XY position using the bed sensors
+**AUTO_Z_HOME_Z**: Home Z using the bed sensors as an endstop
+**AUTO_Z_MEASURE_OFFSET** Z-Offset measured by the inductive probe after AUTO_Z_HOME_Z
+**AUTO_Z_CALIBRATE**: Set the Z-Offset by averaging multiple runs of AUTO_Z_MEASURE_OFFSET
+
 ### Config Reference
 ```
 [auto_z_offset]
 pin:
 #   Pin connected to the Auto Z Offset output pin. This parameter is required.
-z_offset: 0.0
-#   Unused in actual code, but required because this is technically probe.
+z_offset:
+#   The z positon that triggering the bed sensors corre.
+#   default is -0.1
+prepare_gcode:
+#   gcode script to run before probing with auto_z_offset. This is required, and an
+#   example script is provided below.
 #probe_accel:
 #   If set, limits the acceleration of the probing moves (in mm/sec^2).
 #   A sudden large acceleration at the beginning of the probing move may
 #   cause spurious probe triggering, especially if the hotend is heavy.
 #   To prevent that, it may be necessary to reduce the acceleration of
 #   the probing moves via this parameter.
-#endstop_positon:
-#   The z positon that triggering the bed sensors corresponds to.
-#   default is -0.1
 #probe_hop:
 #   The amount to hop between probing with bed sensors and probing with probe.
 #   default is 5.0, min is 4.0 to avoid triggering the probe early
@@ -35,9 +44,6 @@ z_offset: 0.0
 #   The number of times to probe with bed sensors and inductive probe. Note,
 #   this is not the same as `samples`. 
 #   default is 3
-prepare_gcode:
-#   gcode script to run before probing with auto_z_offset. This is required, and an
-#   example script is provided below.
 #speed:
 #samples:
 #sample_retract_dist:
@@ -65,13 +71,13 @@ z_offset: 0.0
 speed:10
 samples: 3
 samples_result: average
-sample_retract_dist: 3.0
+sample_retract_dist: 4.0
 samples_tolerance: 0.05
 samples_tolerance_retries: 5
 
 [auto_z_offset]
 pin: U_1:PC1
-z_offset: 0.0
+z_offset: -0.1
 speed: 10
 probe_accel: 50
 samples: 3

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ ln -s ~/qidi_auto_z_offset/auto_z_offset.py ~/klipper/klippy/extras/auto_z_offse
 
 ### Command Reference
 **AUTO_Z_PROBE**: `AUTO_Z_PROBE` works like the normal PROBE command, using the bed sensors instead.
-**AUTO_Z_OFFSET**: `AUTO_Z_OFFSET` uses the probe and the bed sensor to approximate the Z offset as `auto_z_probe_result + probe_result + z_offset` where `z_offset` is the fixed value set in the auto_z_offset config.
-
+**AUTO_Z_CALIBRATE**: `AUTO_Z_CALIBRATE` uses the bed sensor as a Z endstop, then probes with the inductive probe. Averages the values reported by each to find the approximate offset.
 ### Config Reference
 ```
 [auto_z_offset]
@@ -24,11 +23,18 @@ pin:
 #   cause spurious probe triggering, especially if the hotend is heavy.
 #   To prevent that, it may be necessary to reduce the acceleration of
 #   the probing moves via this parameter.
-z_offset:
-#   Offset to adjust the final z-offset value by after probing . Note that this
-#   is not the same as a traditional probe's z_offset.
+#endstop_positon:
+#   The z positon that triggering the bed sensors corresponds to.
+#   default is -0.1
+#probe_hop:
+#   The amount to hop between probing with bed sensors and probing with probe.
+#   default is 5.0, min is 4.0 to avoid triggering the probe early
+#offset_samples:
+#   The number of times to probe with bed sensors and inductive probe. Note,
+#   this is not the same as `samples`. 
+#   default is 3
 prepare_gcode:
-#   gcode script to run before probing with AUTO_Z. This is required, and an
+#   gcode script to run before probing with auto_z_offset. This is required, and an
 #   example script is provided below.
 #speed:
 #samples:

--- a/auto_z_offset.py
+++ b/auto_z_offset.py
@@ -122,13 +122,15 @@ class AutoZOffsetProbe(probe.PrinterProbe):
 
     def cmd_AUTO_Z_MEASURE_OFFSET(self, gcmd):
         self.cmd_AUTO_Z_HOME_Z(gcmd)
-        gcmd.respond_info("Bed sensor measured offset: z=%.6f" % self.last_z_result)
+        gcmd.respond_info(
+            "%s: bed sensor measured offset: z=%.6f" % (self.name, self.last_z_result)
+        )
         probe = self.printer.lookup_object("probe")
         self.gcode.run_script_from_command(
             "G0 X%f Y%f" % (120 - probe.x_offset, 120 - probe.y_offset)
         )
         pos = probe.run_probe(gcmd)
-        gcmd.respond_info("Probe measured offset: z=%.6f" % pos[2])
+        gcmd.respond_info("%s: probe measured offset: z=%.6f" % (self.name, pos[2]))
         self.lift_probe()
         return pos[2]
 
@@ -141,7 +143,6 @@ class AutoZOffsetProbe(probe.PrinterProbe):
         for _ in range(self.offset_samples):
             offset_total += self.cmd_AUTO_Z_MEASURE_OFFSET(gcmd)
         self.calibrated_z_offset = offset_total / self.offset_samples
-        gcmd.respond_info("Calibrated Z-Offset of %.6f" % self.calibrated_z_offset)
         self.gcode.run_script_from_command(
             "SET_GCODE_OFFSET Z=%f MOVE=0" % neg(self.calibrated_z_offset)
         )

--- a/auto_z_offset.py
+++ b/auto_z_offset.py
@@ -106,14 +106,14 @@ class AutoZOffsetEndstopWrapper:
     def probe_prepare(self, hmove):
         toolhead = self.printer.lookup_object("toolhead")
         self.probe_wrapper.probe_prepare(hmove)
-        if self.probe_accel:
+        if self.probe_accel > 0.0:
             systime = self.printer.get_reactor().monotonic()
             toolhead_info = toolhead.get_status(systime)
             self.old_max_accel = toolhead_info["max_accel"]
             self.gcode.run_script_from_command("M204 S%.3f" % (self.probe_accel,))
 
     def probe_finish(self, hmove):
-        if self.probe_accel:
+        if self.probe_accel > 0.0:
             self.gcode.run_script_from_command("M204 S%.3f" % (self.old_max_accel,))
         self.probe_wrapper.probe_finish(hmove)
 

--- a/auto_z_offset.py
+++ b/auto_z_offset.py
@@ -86,6 +86,11 @@ class AutoZOffsetProbe(probe.PrinterProbe):
             self.cmd_AUTO_Z_CALIBRATE,
             desc=self.cmd_AUTO_Z_CALIBRATE_help,
         )
+        self.gcode.register_command(
+            "AUTO_Z_LOAD_OFFSET",
+            self.cmd_AUTO_Z_LOAD_OFFSET,
+            desc=self.cmd_AUTO_Z_LOAD_OFFSET_help,
+        )
 
     cmd_AUTO_Z_PROBE_help = (
         "Probe Z-height at current XY position using the bed sensors"
@@ -150,6 +155,16 @@ class AutoZOffsetProbe(probe.PrinterProbe):
             "The SAVE_CONFIG command will update the printer config file\n"
             "with the above and restart the printer."
             % (self.name, self.calibrated_z_offset)
+        )
+
+    cmd_AUTO_Z_LOAD_OFFSET_help = "Apply the calibrated_z_offset set in the config file"
+
+    def cmd_AUTO_Z_LOAD_OFFSET(self, gcmd):
+        gcmd.respond_info(
+            "%s: calibrated_z_offset: %.6f" % (self.name, self.calibrated_z_offset)
+        )
+        self.gcode.run_script_from_command(
+            "SET_GCODE_OFFSET Z=%f MOVE=0" % neg(self.calibrated_z_offset)
         )
 
     def lift_probe(self):

--- a/auto_z_offset.py
+++ b/auto_z_offset.py
@@ -91,6 +91,11 @@ class AutoZOffsetProbe(probe.PrinterProbe):
             self.cmd_AUTO_Z_LOAD_OFFSET,
             desc=self.cmd_AUTO_Z_LOAD_OFFSET_help,
         )
+        self.gcode.register_command(
+            "AUTO_Z_SAVE_GCODE_OFFSET",
+            self.cmd_AUTO_Z_SAVE_GCODE_OFFSET,
+            desc=self.cmd_AUTO_Z_SAVE_GCODE_OFFSET_help,
+        )
 
     cmd_AUTO_Z_PROBE_help = (
         "Probe Z-height at current XY position using the bed sensors"
@@ -166,6 +171,24 @@ class AutoZOffsetProbe(probe.PrinterProbe):
         )
         self.gcode.run_script_from_command(
             "SET_GCODE_OFFSET Z=%f MOVE=0" % neg(self.calibrated_z_offset)
+        )
+
+    cmd_AUTO_Z_SAVE_GCODE_OFFSET_help = (
+        "Save the current gcode offset for z as the new calibrated_z_offset"
+    )
+
+    def cmd_AUTO_Z_SAVE_GCODE_OFFSET(self, gcmd):
+        gcode_move = self.printer.lookup_object("gcode_move")
+        self.calibrated_z_offset = gcode_move.homing_position[2]
+        configfile = self.printer.lookup_object("configfile")
+        configfile.set(
+            self.name, "calibrated_z_offset", "%.6f" % self.calibrated_z_offset
+        )
+        gcmd.respond_info(
+            "%s: calibrated_z_offset: %.6f\n"
+            "The SAVE_CONFIG command will update the printer config file\n"
+            "with the above and restart the printer."
+            % (self.name, self.calibrated_z_offset)
         )
 
     def lift_probe(self):

--- a/auto_z_offset.py
+++ b/auto_z_offset.py
@@ -99,6 +99,7 @@ class AutoZOffsetProbe(probe.PrinterProbe):
     cmd_AUTO_Z_PROBE_help = "Probe Z-height at current XY position"
 
     def cmd_AUTO_Z_PROBE(self, gcmd):
+        self.gcode.run_script_from_command("G0 X120 Y120")
         pos = self.run_probe(gcmd)
         gcmd.respond_info("Result is z=%.6f" % (pos[2],))
         self.last_z_result = pos[2]


### PR DESCRIPTION
This PR:
- Adds a `prepare_gcode` config option, like the default `activate_gcode`, but allows for Z movement
- Removes the `AUTO_Z_CALIBRATE` command
- Adds `AUTO_Z_PROBE`, which behaves like normal `PROBE` but with the bed sensors
- Adds `AUTO_Z_OFFSET`, which calculates the offset using the method devised by @Peck07
- Adds an example config to README