### PR TITLE
fix: correct speed used for XY move in AUTO_Z_MEASURE_OFFSET

### DIFF
--- a/auto_z_offset.py
+++ b/auto_z_offset.py
@@ -115,7 +115,7 @@ class AutoZOffsetCommandHelper(probe.ProbeCommandHelper):
         curpos = toolhead.get_position()
         curpos[0] = 120 - main_probe.probe_offsets.x_offset
         curpos[1] = 120 - main_probe.probe_offsets.y_offset
-        self._move(curpos, params["lift_speed"])
+        self._move(curpos, params["speed"])
 
         # Use main probe to measure its own offset
         pos = probe.run_single_probe(main_probe, gcmd)


### PR DESCRIPTION
Using lift_speed caused unnecessarily slow XY motion. This fixes the movement in AUTO_Z_MEASURE_OFFSET to use the configured probing speed.