### PR TITLE
fix(auto_z_offset): replace invalid Coord tuple init with proper args

### DIFF
--- a/auto_z_offset.py
+++ b/auto_z_offset.py
@@ -27,7 +27,7 @@ class AutoZOffsetCommandHelper(probe.ProbeCommandHelper):
 
         # Register commands
         self.gcode = self.printer.lookup_object("gcode")
-        self.last_probe_position = self.gcode.Coord((0., 0., 0.))
+        self.last_probe_position = gcode.Coord(0., 0., 0., 0.)
 
         self.gcode.register_command(
             "AUTO_Z_PROBE",


### PR DESCRIPTION
Fix incompatibility with current Klipper API where gcode.Coord expects separate x, y, z, e arguments instead of a tuple, preventing startup crash during module initialization.